### PR TITLE
Fix `torch.load` of transformers patch when enabling `low_cpu_mem_usage`

### DIFF
--- a/flashmodels/patch/patch.py
+++ b/flashmodels/patch/patch.py
@@ -19,8 +19,11 @@ def rewrite_load():
     """Rewrite `torch.load` in `from_pretrain` in case to use mmap to reduce the CPU
     memory pressure of loading multiple copies of data under multiple processes"""
     source = inspect.getsource(transformers.modeling_utils)
-    modified = re.sub(r"torch\.load\((?![^)]*mmap[^)]*\))([^)]*)\)",
-                      r"torch.load(\g<1>, mmap=True)", source)
+    modified = re.sub(
+        r"torch\.load\((?![^)]*mmap[^)]*\))([^)]*)\)",
+        r"torch.load(\g<1>, mmap=True)"
+        if version.parse(transformers.__version__) <= version.parse('4.36')
+        else r"torch.load(\g<1> mmap=True)", source)
     modified = re.sub(r"partial\(torch.load,(?![^)]*mmap[^)]*\))([^)]*)\)",
                       r"partial(torch.load,\g<1>, mmap=True)", modified)
     if (int(os.environ.get("LOCAL_RANK", 0)) == 0):


### PR DESCRIPTION
- For [Transformers versions ≤ 4.36](https://github.com/huggingface/transformers/blob/a7cab3c283312b8d4de5df3bbe719971e24f4281/src/transformers/modeling_utils.py#L519), apply the original patch.
- For [Transformers versions > 4.37](https://github.com/huggingface/transformers/blob/8e3e145b427196e014f37aa42ba890b9bc94275e/src/transformers/modeling_utils.py#L533-L538), insert a comma to prevent the following error.
![image](https://github.com/user-attachments/assets/927fdd8b-5bec-4f07-a66b-668b7b2070aa)
