### PR TITLE
Support for FSDP + Ulysses and FSDPv2 + TP + SP Parallelism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+hlo/*
 # C extensions
 *.so
 

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -6,7 +6,7 @@ export PYTHONPATH=$PYTHONPATH:$SCRIPTPATH/../
 
 MBS=48              # micro batch size
 SEQLEN=2048         # max sequence length
-NUM_EPOCHS=10       # number epoches
+NUM_EPOCHS=1        # number epoches
 MAX_STEPS=-1        # max steps
 GA=1                # gradients accumulation number
 LOG_INTERVAL=1      # log interval

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -196,14 +196,7 @@ else
     NPROC_PER_NODE=$(nvidia-smi -L | wc -l)
 fi
 
-# 根据DATA来设置log目录，如果DATA中有alpaca，则log目录为log-alpaca，如果DATA中有wikitext，则log目录为log-wiki
 LOG_DIR="log"
-if [[ $DATA == *"alpaca"* ]]; then
-    LOG_DIR="log-alpaca"
-elif [[ $DATA == *"wikitext"* ]]; then
-    LOG_DIR="log-wiki"
-fi
-
 
 mkdir -p $LOG_DIR
 

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -181,13 +181,13 @@ fi
 export XLA_PERSISTENT_CACHE_PATH=./compiled_cache/
 
 MODEL_NAME=$(basename $MODEL_NAME_OR_PATH)
-JOB_NAME="${MODEL_NAME}_${ACCELERATOR}_bs${MBS}_seqlen${SEQLEN}_bf16-${BF16}_fp16-${FP16}_pp${PP_NUM}_tp${TP_NUM}_fsdp${FSDP_NUM}_spmd-${XLA_USE_SPMD}_gc-${GC}_fa-${FLASH_ATTN}"
+JOB_NAME="${MODEL_NAME}_${ACCELERATOR}_bs${MBS}_seqlen${SEQLEN}_bf16-${BF16}_fp16-${FP16}_pp${PP_NUM}_tp${TP_NUM}_fsdp${FSDP_NUM}"
 
 
 [ -z "$RANK" ] && RANK=0
 [ -z "$WORLD_SIZE" ] && WORLD_SIZE=1
 [ -z "$MASTER_ADDR" ] && MASTER_ADDR=127.0.0.1
-[ -z "$MASTER_PORT" ] && MASTER_PORT=9011
+[ -z "$MASTER_PORT" ] && MASTER_PORT=9010
 
 if [ "$WORLD_SIZE" -eq 1 ]; then
     NPROC_PER_NODE=$((FSDP_NUM * TP_NUM * PP_NUM * DP_NUM ))

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -190,7 +190,7 @@ JOB_NAME="${MODEL_NAME}_${ACCELERATOR}_bs${MBS}_seqlen${SEQLEN}_bf16-${BF16}_fp1
 [ -z "$MASTER_PORT" ] && MASTER_PORT=9010
 
 if [ "$WORLD_SIZE" -eq 1 ]; then
-    NPROC_PER_NODE=$((FSDP_NUM * TP_NUM * PP_NUM * DP_NUM ))
+    NPROC_PER_NODE=$((FSDP_NUM * TP_NUM * PP_NUM * DP_NUM))
     [ "$NPROC_PER_NODE" -eq 0 ] && echo "Error: NPROC_PER_NODE is zero." && exit 1
 else
     NPROC_PER_NODE=$(nvidia-smi -L | wc -l)

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -6,7 +6,7 @@ export PYTHONPATH=$PYTHONPATH:$SCRIPTPATH/../
 
 MBS=48              # micro batch size
 SEQLEN=2048         # max sequence length
-NUM_EPOCHS=1        # number epoches
+NUM_EPOCHS=10       # number epoches
 MAX_STEPS=-1        # max steps
 GA=1                # gradients accumulation number
 LOG_INTERVAL=1      # log interval

--- a/flashmodels/accelerators/acc_llama_accelerator.py
+++ b/flashmodels/accelerators/acc_llama_accelerator.py
@@ -83,8 +83,6 @@ class ACCLLAMAAccelerator(Accelerator):
         model.model.config.use_cache = False
 
         if self.args.sp_num > 1 and self.args.spmd_fsdp:
-            # device = lazy_device()
-            # model.to(device)
             model = self.ulysses(model)
             # return model, loader
 
@@ -118,6 +116,7 @@ class ACCLLAMAAccelerator(Accelerator):
                     'logits'] is not None and torch_xla._XLAC._get_xla_sharding_spec(
                         output['logits']) == '':
                 mark_sharding(output['logits'], mesh, ('fsdp', None, None))
+
 
         def get_split_points(llama, num_stages):
             split_points = []

--- a/flashmodels/accelerators/acc_llama_accelerator.py
+++ b/flashmodels/accelerators/acc_llama_accelerator.py
@@ -79,8 +79,8 @@ class ACCLLAMAAccelerator(Accelerator):
         model.model.config.use_cache = False
 
         if self.args.sp_num > 1 and self.args.spmd_fsdp:
-            device = lazy_device()
-            model.to(device)
+            # device = lazy_device()
+            # model.to(device)
             model = self.ulysses(model)
             # return model, loader
 
@@ -206,9 +206,15 @@ class ACCLLAMAAccelerator(Accelerator):
             output = m._original_forward(*args, **kwargs)
             return output
 
-        gc_cnt = self.args.gc_cnt
+        device = lazy_device()
         model.lm_head.forward = MethodType(_forward_linear, model.lm_head)
         for decoder_layer in model.model.layers:
+            is_torchdistX_deferred_init = (LOW_CPU_MEM_USAGE and any(
+                fake.is_fake(param) for param in decoder_layer.parameters()))
+            if is_torchdistX_deferred_init:
+                deferred_init.materialize_module(decoder_layer)
+            decoder_layer.to(device)
+
             if hasattr(decoder_layer.self_attn, "_create_sp_mesh"):
                 decoder_layer.self_attn._create_sp_mesh(self.args.sp_num)
 
@@ -236,7 +242,14 @@ class ACCLLAMAAccelerator(Accelerator):
             #     if gc_cnt > 0:
             #         decoder_layer = checkpoint_module(decoder_layer)
             #         gc_cnt -= 1
-
+        is_torchdistX_deferred_init = (LOW_CPU_MEM_USAGE and any(
+            fake.is_fake(param) for param in model.parameters()))
+        if is_torchdistX_deferred_init:
+            deferred_init.materialize_module(
+                model,
+                check_fn=lambda k: not isinstance(k, type(model.model.layers[0]
+                                                          )))
+        model.to(device)
         return model
 
     def parallel_3d(self, model):
@@ -385,8 +398,10 @@ class ACCLLAMAAccelerator(Accelerator):
             is_torchdistX_deferred_init = (LOW_CPU_MEM_USAGE and any(
                 fake.is_fake(param) for param in decoder_layer.parameters()))
             if is_torchdistX_deferred_init:
+                print("materialize module")
                 deferred_init.materialize_module(decoder_layer)
             decoder_layer.to(device)
+            print(f"after materialize decoder layer fake: {any(fake.is_fake(param) for param in decoder_layer.parameters())}")
             # attn
             if hasattr(decoder_layer.self_attn, "_create_tp_mesh"):
                 decoder_layer.self_attn._create_tp_mesh(

--- a/flashmodels/accelerators/acc_llama_accelerator.py
+++ b/flashmodels/accelerators/acc_llama_accelerator.py
@@ -209,11 +209,16 @@ class ACCLLAMAAccelerator(Accelerator):
         device = lazy_device()
         model.lm_head.forward = MethodType(_forward_linear, model.lm_head)
         for decoder_layer in model.model.layers:
-            is_torchdistX_deferred_init = (LOW_CPU_MEM_USAGE and any(
-                fake.is_fake(param) for param in decoder_layer.parameters()))
-            if is_torchdistX_deferred_init:
-                deferred_init.materialize_module(decoder_layer)
-            decoder_layer.to(device)
+            # is_torchdistX_deferred_init = (LOW_CPU_MEM_USAGE and any(
+            #     fake.is_fake(param) for param in decoder_layer.parameters()))
+            # if is_torchdistX_deferred_init:
+            #     print("materialize module")
+            #     deferred_init.materialize_module(decoder_layer)
+            # decoder_layer.to(device)
+            # # print(f"after materialize decoder layer fake: {any(fake.is_fake(param) for param in decoder_layer.parameters())}")
+            # for param in decoder_layer.parameters():
+            #     print(f"param device: {param.device}")
+
 
             if hasattr(decoder_layer.self_attn, "_create_sp_mesh"):
                 decoder_layer.self_attn._create_sp_mesh(self.args.sp_num)
@@ -238,18 +243,21 @@ class ACCLLAMAAccelerator(Accelerator):
                 MethodType(_forward_linear, decoder_layer.mlp.up_proj)
             decoder_layer.mlp.down_proj.forward = \
                 MethodType(_forward_linear, decoder_layer.mlp.down_proj)
+            
+            # mark_sharding(decoder_layer.self_attn.q_proj.weight,
+            #               self.sp_mesh_3d, (0, 1))
             # if self.args.gc:
             #     if gc_cnt > 0:
             #         decoder_layer = checkpoint_module(decoder_layer)
             #         gc_cnt -= 1
-        is_torchdistX_deferred_init = (LOW_CPU_MEM_USAGE and any(
-            fake.is_fake(param) for param in model.parameters()))
-        if is_torchdistX_deferred_init:
-            deferred_init.materialize_module(
-                model,
-                check_fn=lambda k: not isinstance(k, type(model.model.layers[0]
-                                                          )))
-        model.to(device)
+        # is_torchdistX_deferred_init = (LOW_CPU_MEM_USAGE and any(
+        #     fake.is_fake(param) for param in model.parameters()))
+        # if is_torchdistX_deferred_init:
+        #     deferred_init.materialize_module(
+        #         model,
+        #         check_fn=lambda k: not isinstance(k, type(model.model.layers[0]
+        #                                                   )))
+        # model.to(device)
         return model
 
     def parallel_3d(self, model):

--- a/flashmodels/accelerators/acc_llama_accelerator.py
+++ b/flashmodels/accelerators/acc_llama_accelerator.py
@@ -388,7 +388,6 @@ class ACCLLAMAAccelerator(Accelerator):
         col_dim = 1 if self.args.use_zero3 or self.args.fsdp_num > 1 else None
 
         device = lazy_device()
-        gc_cnt = self.args.gc_cnt
         for decoder_layer in model.model.layers:
             is_torchdistX_deferred_init = (LOW_CPU_MEM_USAGE and any(
                 fake.is_fake(param) for param in decoder_layer.parameters()))

--- a/flashmodels/accelerators/acc_llama_accelerator.py
+++ b/flashmodels/accelerators/acc_llama_accelerator.py
@@ -143,6 +143,7 @@ class ACCLLAMAAccelerator(Accelerator):
 
         config.dist.dp.size = self.args.dp_num
         config.dist.tp.size = self.args.tp_num
+        config.dist.sp.size = self.args.sp_num
 
         config.dist.pp.size = self.args.pp_num
         config.dist.pp.num_micro_batches = self.args.gradient_accumulation_steps

--- a/flashmodels/accelerators/acc_llama_accelerator.py
+++ b/flashmodels/accelerators/acc_llama_accelerator.py
@@ -10,7 +10,7 @@ import torchacc as ta
 from torch_xla.distributed.fsdp import consolidate_sharded_model_checkpoints
 from torchacc import lazy_device
 from torchacc.dist.tp import Mesh, mark_sharding
-from torchacc.utils.checkpoint import checkpoint_module
+from torchacc.utils.checkpoint import checkpoint_module, gradient_checkpoint
 
 import flashmodels.tensor_parallel as tensor_parallel
 from flashmodels.accelerators.accelerator import (Accelerator,
@@ -28,7 +28,7 @@ except ImportError:
 class ACCLLAMAAccelerator(Accelerator):
     def __init__(self, args):
         super().__init__(args)
-        devices_ids = np.arange(self.args.world_size)
+        devices_ids = np.arange(self.args.world_size) # 4 (0,1) (2,3)
         # init mesh for SPMD
         # TP
         self.tp_row_mesh = None
@@ -45,8 +45,10 @@ class ACCLLAMAAccelerator(Accelerator):
                                 (self.args.dp_num, self.args.tp_num, 1))
         # Ulysses SP
         self.sp_mesh_3d = None
-        if self.args.sp_num > 1:
-            self.sp_mesh_3d = Mesh(devices_ids, (1, self.args.sp_num, 1))
+        if self.args.sp_num > 1 and self.args.spmd_fsdp:# 2
+            self.sp_mesh_3d = Mesh(devices_ids, ((int)(self.args.world_size / self.args.sp_num), self.args.sp_num, 1)) # [2,2]
+            # self.sp_mesh_3d = Mesh(devices_ids, (1, self.args.sp_num, 1))
+            # [4,1] -> 
 
     def accelerate(self, model, loader):
         if self.args.lora:
@@ -76,11 +78,11 @@ class ACCLLAMAAccelerator(Accelerator):
     def accelerate_internal(self, model, loader):
         model.model.config.use_cache = False
 
-        if self.args.sp_num > 1:
+        if self.args.sp_num > 1 and self.args.spmd_fsdp:
             device = lazy_device()
             model.to(device)
             model = self.ulysses(model)
-            return model, loader
+            # return model, loader
 
         if self.args.tp_num > 1 and self.args.pp_num == 1:
             model = self.tensor_parallel(model)
@@ -108,8 +110,10 @@ class ACCLLAMAAccelerator(Accelerator):
 
     def get_config(self, model):
         def _shard_output_callable(output, mesh):
-            if not isinstance(output, tuple) and output['logits'] is not None:
-                mark_sharding(output['logits'], mesh, ('fsdp', None, None))
+            # if not isinstance(output, tuple) and output['logits'] is not None:
+                # print(f"output_logits: {output['logits'].shape}")
+                # mark_sharding(output['logits'], mesh, ('fsdp', None, None))
+            pass
 
         def get_split_points(llama, num_stages):
             split_points = []
@@ -177,19 +181,19 @@ class ACCLLAMAAccelerator(Accelerator):
         https://github.com/microsoft/DeepSpeed/tree/master/blogs/deepspeed-ulysses
         """
         def _grad_shard_sp(grad):
-            mark_sharding(grad, self.sp_mesh_3d, (0, 1, 2))
+            mark_sharding(grad, self.sp_mesh_3d, (0, 1, None))
             return grad
 
         def _forward_linear(m, *args):
             h = args[0]
             out = torch.einsum("bij,jk->bik", h, m.weight.T)
-            mark_sharding(out, self.sp_mesh_3d, (0, 1, 2))
+            mark_sharding(out, self.sp_mesh_3d, (0, 1, None))
             out.register_hook(lambda grad: _grad_shard_sp(grad))
             return out
 
         def _forward_sp(m, *args, **kwargs):
             h = args[0] if len(args) > 0 else kwargs.get("hidden_states")
-            mark_sharding(h, self.sp_mesh_3d, (0, 1, 2))
+            mark_sharding(h, self.sp_mesh_3d, (0, 1, None))
             h.register_hook(lambda grad: _grad_shard_sp(grad))
             if len(args) > 0:
                 as_list = list(args)
@@ -364,12 +368,15 @@ class ACCLLAMAAccelerator(Accelerator):
             out_h = output[0] if isinstance(output, tuple) else output
             # shard on sequence dim.
             mark_sharding(out_h, self.tp_mesh, (0, 1, 2))
-            out_h.register_hook(lambda grad: _grad_ag(grad))
+            if out_h.requires_grad:
+                out_h.register_hook(lambda grad: _grad_ag(grad))
             return output
 
         row_dim = 0 if self.args.use_zero3 else None
         col_dim = 1 if self.args.use_zero3 else None
+        # TODO: 切分Embedding，判断显存是否大
         device = lazy_device()
+        gc_cnt = self.args.gc_cnt
         for decoder_layer in model.model.layers:
             is_torchdistX_deferred_init = (LOW_CPU_MEM_USAGE and any(
                 fake.is_fake(param) for param in decoder_layer.parameters()))
@@ -444,8 +451,9 @@ class ACCLLAMAAccelerator(Accelerator):
                 decoder_layer.mlp.forward = \
                     MethodType(_forward_ag_sp, decoder_layer.mlp)
             if self.args.gc:
-                decoder_layer.self_attn.core_attn = checkpoint_module(
-                    decoder_layer.self_attn.core_attn)
+                if gc_cnt > 0:
+                    decoder_layer = checkpoint_module(decoder_layer)
+                    gc_cnt -= 1
 
         is_torchdistX_deferred_init = (LOW_CPU_MEM_USAGE and any(
             fake.is_fake(param) for param in model.parameters()))

--- a/flashmodels/accelerators/acc_llama_accelerator.py
+++ b/flashmodels/accelerators/acc_llama_accelerator.py
@@ -188,13 +188,15 @@ class ACCLLAMAAccelerator(Accelerator):
             h = args[0]
             out = torch.einsum("bij,jk->bik", h, m.weight.T)
             mark_sharding(out, self.sp_mesh_3d, (0, 1, None))
-            out.register_hook(lambda grad: _grad_shard_sp(grad))
+            if out.requires_grad:
+                out.register_hook(lambda grad: _grad_shard_sp(grad))
             return out
 
         def _forward_sp(m, *args, **kwargs):
             h = args[0] if len(args) > 0 else kwargs.get("hidden_states")
             mark_sharding(h, self.sp_mesh_3d, (0, 1, None))
-            h.register_hook(lambda grad: _grad_shard_sp(grad))
+            if h.requires_grad:
+                h.register_hook(lambda grad: _grad_shard_sp(grad))
             if len(args) > 0:
                 as_list = list(args)
                 as_list[0] = h
@@ -204,6 +206,7 @@ class ACCLLAMAAccelerator(Accelerator):
             output = m._original_forward(*args, **kwargs)
             return output
 
+        gc_cnt = self.args.gc_cnt
         model.lm_head.forward = MethodType(_forward_linear, model.lm_head)
         for decoder_layer in model.model.layers:
             if hasattr(decoder_layer.self_attn, "_create_sp_mesh"):
@@ -229,9 +232,10 @@ class ACCLLAMAAccelerator(Accelerator):
                 MethodType(_forward_linear, decoder_layer.mlp.up_proj)
             decoder_layer.mlp.down_proj.forward = \
                 MethodType(_forward_linear, decoder_layer.mlp.down_proj)
-            if self.args.gc:
-                decoder_layer.self_attn.core_attn = checkpoint_module(
-                    decoder_layer.self_attn.core_attn)
+            # if self.args.gc:
+            #     if gc_cnt > 0:
+            #         decoder_layer = checkpoint_module(decoder_layer)
+            #         gc_cnt -= 1
 
         return model
 

--- a/flashmodels/accelerators/acc_llama_accelerator.py
+++ b/flashmodels/accelerators/acc_llama_accelerator.py
@@ -17,6 +17,7 @@ from flashmodels.accelerators.accelerator import (Accelerator,
                                                   AcceleratorFactory)
 from flashmodels.logger import logger
 from flashmodels.utils import get_last_step_from_ckpt
+import torch_xla
 
 LOW_CPU_MEM_USAGE = bool(int(os.environ.get("LOW_CPU_MEM_USAGE", "0")))
 try:
@@ -114,10 +115,8 @@ class ACCLLAMAAccelerator(Accelerator):
 
     def get_config(self, model):
         def _shard_output_callable(output, mesh):
-            # if not isinstance(output, tuple) and output['logits'] is not None:
-                # print(f"output_logits: {output['logits'].shape}")
-                # mark_sharding(output['logits'], mesh, ('fsdp', None, None))
-            pass
+            if not isinstance(output, tuple) and output['logits'] is not None and torch_xla._XLAC._get_xla_sharding_spec(output['logits']) == '':
+                mark_sharding(output['logits'], mesh, ('fsdp', None, None))
 
         def get_split_points(llama, num_stages):
             split_points = []
@@ -305,7 +304,7 @@ class ACCLLAMAAccelerator(Accelerator):
             return out
 
         assert os.environ.get("ACC_LLAMA_MLP") != "1"
-        dp_dim = "dp" if self.args.use_zero3 else None
+        dp_dim = "dp" if (self.args.use_zero3 or self.args.fsdp_num > 1) else None
         for name, m in model.named_modules():
             # attn
             if "q_proj" in name:
@@ -325,7 +324,7 @@ class ACCLLAMAAccelerator(Accelerator):
                 context.tp_mark_sharding(m.weight, (dp_dim, "tp"))
 
             # attn linear
-            if self.args.use_zero2 or self.args.use_zero3:
+            if self.args.use_zero2 or self.args.use_zero3 or self.args.fsdp_num > 1:
                 tp_dp_linear = functools.partial(_forward_linear,
                                                  old_specs=("tp", None),
                                                  new_specs=("tp", "dp"))
@@ -401,8 +400,8 @@ class ACCLLAMAAccelerator(Accelerator):
                 out_h.register_hook(lambda grad: _grad_ag(grad))
             return output
 
-        row_dim = 0 if self.args.use_zero3 else None
-        col_dim = 1 if self.args.use_zero3 else None
+        row_dim = 0 if (self.args.use_zero3 or self.args.fsdp_num > 1) else None
+        col_dim = 1 if self.args.use_zero3 or self.args.fsdp_num > 1 else None
         # TODO: 切分Embedding，判断显存是否大
         device = lazy_device()
         gc_cnt = self.args.gc_cnt

--- a/flashmodels/accelerators/acc_llama_accelerator.py
+++ b/flashmodels/accelerators/acc_llama_accelerator.py
@@ -211,15 +211,6 @@ class ACCLLAMAAccelerator(Accelerator):
         device = lazy_device()
         model.lm_head.forward = MethodType(_forward_linear, model.lm_head)
         for decoder_layer in model.model.layers:
-            # is_torchdistX_deferred_init = (LOW_CPU_MEM_USAGE and any(
-            #     fake.is_fake(param) for param in decoder_layer.parameters()))
-            # if is_torchdistX_deferred_init:
-            #     print("materialize module")
-            #     deferred_init.materialize_module(decoder_layer)
-            # decoder_layer.to(device)
-            # # print(f"after materialize decoder layer fake: {any(fake.is_fake(param) for param in decoder_layer.parameters())}")
-            # for param in decoder_layer.parameters():
-            #     print(f"param device: {param.device}")
 
             if hasattr(decoder_layer.self_attn, "_create_sp_mesh"):
                 decoder_layer.self_attn._create_sp_mesh(self.args.sp_num)
@@ -245,20 +236,10 @@ class ACCLLAMAAccelerator(Accelerator):
             decoder_layer.mlp.down_proj.forward = \
                 MethodType(_forward_linear, decoder_layer.mlp.down_proj)
 
-            # mark_sharding(decoder_layer.self_attn.q_proj.weight,
-            #               self.sp_mesh_3d, (0, 1))
             # if self.args.gc:
             #     if gc_cnt > 0:
             #         decoder_layer = checkpoint_module(decoder_layer)
             #         gc_cnt -= 1
-        # is_torchdistX_deferred_init = (LOW_CPU_MEM_USAGE and any(
-        #     fake.is_fake(param) for param in model.parameters()))
-        # if is_torchdistX_deferred_init:
-        #     deferred_init.materialize_module(
-        #         model,
-        #         check_fn=lambda k: not isinstance(k, type(model.model.layers[0]
-        #                                                   )))
-        # model.to(device)
         return model
 
     def parallel_3d(self, model):

--- a/flashmodels/accelerators/acc_llama_accelerator.py
+++ b/flashmodels/accelerators/acc_llama_accelerator.py
@@ -117,7 +117,6 @@ class ACCLLAMAAccelerator(Accelerator):
                         output['logits']) == '':
                 mark_sharding(output['logits'], mesh, ('fsdp', None, None))
 
-
         def get_split_points(llama, num_stages):
             split_points = []
             assert llama.config.num_hidden_layers >= num_stages

--- a/flashmodels/arguments.py
+++ b/flashmodels/arguments.py
@@ -268,6 +268,7 @@ def parse():
                     tp_num=args.tp_num,
                     use_tp=(args.tp_num > 1),
                     spmd_fsdp=args.spmd_fsdp)
+
     if args.model_type == "gemma" and args.accelerator == 'acc':
         patch_gemma()
 

--- a/flashmodels/arguments.py
+++ b/flashmodels/arguments.py
@@ -263,7 +263,11 @@ def parse():
 
     if args.model_type == "llama" and args.accelerator == 'acc' and (
             args.fp16 or args.bf16):
+<<<<<<< HEAD
         patch_llama(fsdp_num=args.fsdp_num, use_tp=(args.tp_num > 1))
+=======
+        patch_llama(fsdp_num=args.fsdp_num, ulysses_sp_num=args.sp_num, tp_num=args.tp_num, use_tp=(args.tp_num > 1), spmd_fsdp=args.spmd_fsdp)
+>>>>>>> c28a3ce... support fa + tp + sp + fsdp
     if args.model_type == "gemma" and args.accelerator == 'acc':
         patch_gemma()
 

--- a/flashmodels/arguments.py
+++ b/flashmodels/arguments.py
@@ -263,11 +263,11 @@ def parse():
 
     if args.model_type == "llama" and args.accelerator == 'acc' and (
             args.fp16 or args.bf16):
-<<<<<<< HEAD
-        patch_llama(fsdp_num=args.fsdp_num, use_tp=(args.tp_num > 1))
-=======
-        patch_llama(fsdp_num=args.fsdp_num, ulysses_sp_num=args.sp_num, tp_num=args.tp_num, use_tp=(args.tp_num > 1), spmd_fsdp=args.spmd_fsdp)
->>>>>>> c28a3ce... support fa + tp + sp + fsdp
+        patch_llama(fsdp_num=args.fsdp_num,
+                    ulysses_sp_num=args.sp_num,
+                    tp_num=args.tp_num,
+                    use_tp=(args.tp_num > 1),
+                    spmd_fsdp=args.spmd_fsdp)
     if args.model_type == "gemma" and args.accelerator == 'acc':
         patch_gemma()
 

--- a/flashmodels/builder.py
+++ b/flashmodels/builder.py
@@ -33,13 +33,13 @@ class Builder(object):
         self.args = args
         self._init_fn = lambda func, *args, **kwargs: func(*args, **kwargs)
         if LOW_CPU_MEM_USAGE:
-            if self.args.sp_num == 1:
-                self._init_fn = lambda func, *args, **kwargs: \
-                    deferred_init.deferred_init(func, *args, **kwargs)
-            else:
-                logger.warning(
-                    "LOW_CPU_MEM_USAGE with lazy init does not support for ulysses now."
-                )
+            # if self.args.sp_num == 1:
+            self._init_fn = lambda func, *args, **kwargs: \
+                deferred_init.deferred_init(func, *args, **kwargs)
+            # else:
+            #     logger.warning(
+            #         "LOW_CPU_MEM_USAGE with lazy init does not support for ulysses now."
+            #     )
 
     def build_model_dataloader(self):
         if self.args.resume_from_checkpoint and \

--- a/flashmodels/builder.py
+++ b/flashmodels/builder.py
@@ -33,13 +33,8 @@ class Builder(object):
         self.args = args
         self._init_fn = lambda func, *args, **kwargs: func(*args, **kwargs)
         if LOW_CPU_MEM_USAGE:
-            # if self.args.sp_num == 1:
             self._init_fn = lambda func, *args, **kwargs: \
                 deferred_init.deferred_init(func, *args, **kwargs)
-            # else:
-            #     logger.warning(
-            #         "LOW_CPU_MEM_USAGE with lazy init does not support for ulysses now."
-            #     )
 
     def build_model_dataloader(self):
         if self.args.resume_from_checkpoint and \
@@ -61,11 +56,9 @@ class Builder(object):
         config = AutoConfig.from_pretrained(self.args.model_name_or_path,
                                             trust_remote_code=True)
 
-        model = self._init_fn(
-            AutoModelForCausalLM.from_config,
-            config,
-            #  attn_implementation="flash_attention_2" if self.args.use_flash_attn else "eager",
-            trust_remote_code=True)
+        model = self._init_fn(AutoModelForCausalLM.from_config,
+                              config,
+                              trust_remote_code=True)
         return model
 
     def build_model_from_pretrain(self):
@@ -79,12 +72,10 @@ class Builder(object):
             # from hugging face
             has_weight = True
         if has_weight:
-            return self._init_fn(
-                AutoModelForCausalLM.from_pretrained,
-                self.args.model_name_or_path,
-                #  attn_implementation="flash_attention_2" if self.args.use_flash_attn else "eager",
-                cache_dir=self.args.cache_dir,
-                trust_remote_code=True)
+            return self._init_fn(AutoModelForCausalLM.from_pretrained,
+                                 self.args.model_name_or_path,
+                                 cache_dir=self.args.cache_dir,
+                                 trust_remote_code=True)
         if self.args.local_rank == 0:
             logger.warning("Model weights are not been set, because" \
                            " there is no .bin file in path %s." %    \

--- a/flashmodels/builder.py
+++ b/flashmodels/builder.py
@@ -60,9 +60,13 @@ class Builder(object):
     def build_model_from_ckpt(self):
         config = AutoConfig.from_pretrained(self.args.model_name_or_path,
                                             trust_remote_code=True)
-        return self._init_fn(AutoModelForCausalLM.from_config,
-                             config,
-                             trust_remote_code=True)
+
+        model = self._init_fn(
+            AutoModelForCausalLM.from_config,
+            config,
+            #  attn_implementation="flash_attention_2" if self.args.use_flash_attn else "eager",
+            trust_remote_code=True)
+        return model
 
     def build_model_from_pretrain(self):
         has_weight = False
@@ -75,10 +79,12 @@ class Builder(object):
             # from hugging face
             has_weight = True
         if has_weight:
-            return self._init_fn(AutoModelForCausalLM.from_pretrained,
-                                 self.args.model_name_or_path,
-                                 cache_dir=self.args.cache_dir,
-                                 trust_remote_code=True)
+            return self._init_fn(
+                AutoModelForCausalLM.from_pretrained,
+                self.args.model_name_or_path,
+                #  attn_implementation="flash_attention_2" if self.args.use_flash_attn else "eager",
+                cache_dir=self.args.cache_dir,
+                trust_remote_code=True)
         if self.args.local_rank == 0:
             logger.warning("Model weights are not been set, because" \
                            " there is no .bin file in path %s." %    \

--- a/flashmodels/datasets/hf_dataset.py
+++ b/flashmodels/datasets/hf_dataset.py
@@ -66,9 +66,8 @@ def get_hf_dataset_loader(tokenizer, args):
         train_sampler = torch.utils.data.distributed.DistributedSampler(
             train_dataset,
             num_replicas=(1 if args.tp_num > 1 else data_num_replicas),
-            rank=(0 if args.tp_num > 1 else args.global_rank %
-                  data_num_replicas),
-            shuffle=True)
+            rank=(0 if args.tp_num > 1 else args.global_rank // args.sp_num),
+            shuffle=False)
 
     bs = args.micro_batch_size
     if args.tp_num > 1:

--- a/flashmodels/datasets/hf_dataset.py
+++ b/flashmodels/datasets/hf_dataset.py
@@ -53,7 +53,9 @@ def get_hf_dataset_loader(tokenizer, args):
     train_dataset = lm_datasets["train"]
     # DataLoader creation
     train_sampler = None
-    data_num_replicas = args.fsdp_num * args.dp_num
+    data_num_replicas = args.fsdp_num * args.dp_num / args.sp_num
+    # data_num_replicas = args.fsdp_num * args.dp_num
+    
     if args.pp_num > 1:
         # disable sampler for now
         # the rank below should be:
@@ -74,7 +76,9 @@ def get_hf_dataset_loader(tokenizer, args):
     if args.pp_num > 1:
         bs *= args.gradient_accumulation_steps
     if args.spmd_fsdp:
-        bs *= args.fsdp_num
+        bs *= int(args.fsdp_num / args.sp_num)
+        # bs *= args.fsdp_num
+    print(f"{bs=}")
     train_dataloader = torch.utils.data.DataLoader(
         train_dataset,
         batch_size=bs,

--- a/flashmodels/datasets/hf_dataset.py
+++ b/flashmodels/datasets/hf_dataset.py
@@ -53,7 +53,7 @@ def get_hf_dataset_loader(tokenizer, args):
     train_dataset = lm_datasets["train"]
     # DataLoader creation
     train_sampler = None
-    data_num_replicas = args.fsdp_num * args.dp_num / args.sp_num
+    data_num_replicas = args.fsdp_num * args.dp_num // args.sp_num
     # data_num_replicas = args.fsdp_num * args.dp_num
     
     if args.pp_num > 1:
@@ -76,7 +76,7 @@ def get_hf_dataset_loader(tokenizer, args):
     if args.pp_num > 1:
         bs *= args.gradient_accumulation_steps
     if args.spmd_fsdp:
-        bs *= int(args.fsdp_num / args.sp_num)
+        bs *= args.fsdp_num // args.sp_num
         # bs *= args.fsdp_num
     print(f"{bs=}")
     train_dataloader = torch.utils.data.DataLoader(

--- a/flashmodels/datasets/hf_dataset.py
+++ b/flashmodels/datasets/hf_dataset.py
@@ -75,9 +75,10 @@ def get_hf_dataset_loader(tokenizer, args):
     if args.pp_num > 1:
         bs *= args.gradient_accumulation_steps
     if args.spmd_fsdp:
-        bs *= args.fsdp_num // args.sp_num
-        # bs *= args.fsdp_num
-    print(f"{bs=}")
+        dp_num = args.fsdp_num // args.sp_num
+        if dp_num != 0:
+            bs *= args.fsdp_num // args.sp_num
+
     train_dataloader = torch.utils.data.DataLoader(
         train_dataset,
         batch_size=bs,

--- a/flashmodels/datasets/hf_dataset.py
+++ b/flashmodels/datasets/hf_dataset.py
@@ -55,7 +55,7 @@ def get_hf_dataset_loader(tokenizer, args):
     train_sampler = None
     data_num_replicas = args.fsdp_num * args.dp_num // args.sp_num
     # data_num_replicas = args.fsdp_num * args.dp_num
-    
+
     if args.pp_num > 1:
         # disable sampler for now
         # the rank below should be:

--- a/flashmodels/datasets/hf_dataset.py
+++ b/flashmodels/datasets/hf_dataset.py
@@ -55,7 +55,6 @@ def get_hf_dataset_loader(tokenizer, args):
     train_sampler = None
     data_num_replicas = args.fsdp_num * args.dp_num // args.sp_num
     # data_num_replicas = args.fsdp_num * args.dp_num
-
     if args.pp_num > 1:
         # disable sampler for now
         # the rank below should be:

--- a/flashmodels/datasets/hf_dataset.py
+++ b/flashmodels/datasets/hf_dataset.py
@@ -77,7 +77,7 @@ def get_hf_dataset_loader(tokenizer, args):
     if args.spmd_fsdp:
         dp_num = args.fsdp_num // args.sp_num
         if dp_num != 0:
-            bs *= args.fsdp_num // args.sp_num
+            bs *= dp_num
 
     train_dataloader = torch.utils.data.DataLoader(
         train_dataset,

--- a/flashmodels/datasets/hf_dataset.py
+++ b/flashmodels/datasets/hf_dataset.py
@@ -66,7 +66,8 @@ def get_hf_dataset_loader(tokenizer, args):
         train_sampler = torch.utils.data.distributed.DistributedSampler(
             train_dataset,
             num_replicas=(1 if args.tp_num > 1 else data_num_replicas),
-            rank=(0 if args.tp_num > 1 else args.global_rank),
+            rank=(0 if args.tp_num > 1 else args.global_rank %
+                  data_num_replicas),
             shuffle=True)
 
     bs = args.micro_batch_size

--- a/flashmodels/patch/llama_model.py
+++ b/flashmodels/patch/llama_model.py
@@ -18,7 +18,6 @@ from transformers.models.llama.modeling_llama import (ACT2FN, LlamaRMSNorm,
 
 import flashmodels.tensor_parallel as tensor_parallel
 
-
 class Linear3d(nn.Module):
     """ Custom Linear layer"""
     def __init__(self, in_dim, out_dim, keep_dim):
@@ -253,7 +252,7 @@ class LlamaAttention(nn.Module):
         query_states = query_states.transpose(1, 2)
         key_states = key_states.transpose(1, 2)
         value_states = value_states.transpose(1, 2)
-
+        print(f"{query_states.size()=} {key_states.size()=} {value_states.size()=}")
         if self.sp_mesh_4d is not None:
             # insert all-to-all
             mark_sharding(query_states, self.sp_mesh_4d, (0, 1, 2, 3))

--- a/flashmodels/patch/llama_model.py
+++ b/flashmodels/patch/llama_model.py
@@ -196,86 +196,9 @@ class LlamaModel(LlamaPreTrainedModel):
         past_key_values: Cache,
         output_attentions: bool,
     ):
-        # TODO: As of torch==2.2.0, the `attention_mask` passed to the model in `generate` is 2D and of dynamic length even when the static
-        # KV cache is used. This is an issue for torch.compile which then recaptures cudagraphs at each decode steps due to the dynamic shapes.
-        # (`recording cudagraph tree for symint key 13`, etc.), which is VERY slow. A workaround is `@torch.compiler.disable`, but this prevents using
-        # `fullgraph=True`. See more context in https://github.com/huggingface/transformers/pull/29114
-
-        if self.config._attn_implementation == "flash_attention_2":
-            if attention_mask is not None and 0.0 in attention_mask:
-                return attention_mask
-            return None
-
-        # For SDPA, when possible, we will rely on its `is_causal` argument instead of its `attn_mask` argument, in
-        # order to dispatch on Flash Attention 2. This feature is not compatible with static cache, as SDPA will fail
-        # to infer the attention mask.
-        past_seen_tokens = past_key_values.get_seq_length(
-        ) if past_key_values is not None else 0
-        using_static_cache = isinstance(past_key_values, StaticCache)
-
-        # When output attentions is True, sdpa implementation's forward method calls the eager implementation's forward
-        if self.config._attn_implementation == "sdpa" and not using_static_cache and not output_attentions:
-            if AttentionMaskConverter._ignore_causal_mask_sdpa(
-                    attention_mask,
-                    inputs_embeds=input_tensor,
-                    past_key_values_length=past_seen_tokens,
-                    is_training=self.training,
-            ):
-                return None
-
-        dtype, device = input_tensor.dtype, input_tensor.device
-        min_dtype = torch.finfo(dtype).min
-        sequence_length = input_tensor.shape[1]
-        if using_static_cache:
-            target_length = past_key_values.get_max_length()
-        else:
-            target_length = (attention_mask.shape[-1] if isinstance(
-                attention_mask, torch.Tensor) else past_seen_tokens +
-                             sequence_length + 1)
-
-        if attention_mask is not None and attention_mask.dim() == 4:
-            # in this case we assume that the mask comes already in inverted form and requires no inversion or slicing
-            if attention_mask.max() != 0:
-                raise ValueError(
-                    "Custom 4D attention mask should be passed in inverted form with max==0`"
-                )
-            causal_mask = attention_mask
-        else:
-            causal_mask = torch.full((sequence_length, target_length),
-                                     fill_value=min_dtype,
-                                     dtype=dtype,
-                                     device=device)
-            if sequence_length != 1:
-                causal_mask = torch.triu(causal_mask, diagonal=1)
-            causal_mask *= torch.arange(
-                target_length, device=device) > cache_position.reshape(-1, 1)
-            causal_mask = causal_mask[None, None, :, :].expand(
-                input_tensor.shape[0], 1, -1, -1)
-            if attention_mask is not None:
-                causal_mask = causal_mask.clone(
-                )  # copy to contiguous memory for in-place edit
-                mask_length = attention_mask.shape[-1]
-                padding_mask = causal_mask[:, :, :, :
-                                           mask_length] + attention_mask[:,
-                                                                         None,
-                                                                         None, :]
-                padding_mask = padding_mask == 0
-                causal_mask[:, :, :, :
-                            mask_length] = causal_mask[:, :, :, :
-                                                       mask_length].masked_fill(
-                                                           padding_mask,
-                                                           min_dtype)
-        if (self.config._attn_implementation == "sdpa"
-                and attention_mask is not None
-                and attention_mask.device.type == "cuda"
-                and not output_attentions):
-            # Attend to all tokens in fully masked rows in the causal_mask, for example the relevant first rows when
-            # using left padding. This is required by F.scaled_dot_product_attention memory-efficient attention path.
-            # Details: https://github.com/pytorch/pytorch/issues/110213
-            causal_mask = AttentionMaskConverter._unmask_unattended(
-                causal_mask, min_dtype)
-
-        return causal_mask
+        if attention_mask is not None:
+            return attention_mask
+        return None
 
 
 class Linear3d(nn.Module):

--- a/flashmodels/patch/llama_model.py
+++ b/flashmodels/patch/llama_model.py
@@ -533,6 +533,10 @@ def flash_attn_fwd(
         device_ids = np.array(range(fsdp_num))
         mesh = xs.Mesh(device_ids, (fsdp_num, 1), ('fsdp', 'tensor'))
         partition_spec = ('fsdp', None, None)
+        if ulysses_sp_num > 1:
+            mesh = xs.Mesh(device_ids, (fsdp_num // ulysses_sp_num, ulysses_sp_num), ('dp', 'sp'))
+            partition_spec = ('dp', 'sp', None)
+        
         output = spmd_flash_attn_varlen_xla(q,
                                             k,
                                             v,

--- a/flashmodels/patch/llama_model.py
+++ b/flashmodels/patch/llama_model.py
@@ -252,7 +252,7 @@ class LlamaAttention(nn.Module):
         query_states = query_states.transpose(1, 2)
         key_states = key_states.transpose(1, 2)
         value_states = value_states.transpose(1, 2)
-        print(f"{query_states.size()=} {key_states.size()=} {value_states.size()=}")
+
         if self.sp_mesh_4d is not None:
             # insert all-to-all
             mark_sharding(query_states, self.sp_mesh_4d, (0, 1, 2, 3))
@@ -474,8 +474,10 @@ def flash_attn_fwd(
         output = cp_func(q, 
                             k,
                             v,
-                            torch.tensor([q_len]),
-                            torch.tensor([q_len]),
+                            # torch.tensor([q_len * ulysses_sp_num]),
+                            # torch.tensor([q_len * ulysses_sp_num]),
+                            None,
+                            None, # Use fixed len FA
                             dropout_p = 0.0,
                             softmax_scale=None,
                             causal=True,

--- a/flashmodels/patch/llama_model.py
+++ b/flashmodels/patch/llama_model.py
@@ -1,22 +1,283 @@
 import math
 import os
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import einops
 import numpy as np
 import torch
 import torch_xla.core.xla_model as xm
 import torch_xla.distributed.spmd as xs
+import torchacc.ops.context_parallel as context_parallel
 import transformers
 from packaging import version
 from torch import nn
 from torchacc.dist.tp import Mesh, mark_sharding
+from transformers.cache_utils import Cache, DynamicCache, StaticCache
+from transformers.modeling_outputs import BaseModelOutputWithPast
 from transformers.models.llama.configuration_llama import LlamaConfig
-from transformers.models.llama.modeling_llama import (ACT2FN, LlamaRMSNorm,
+from transformers.models.llama.modeling_llama import (ACT2FN,
+                                                      LlamaPreTrainedModel,
+                                                      LlamaRMSNorm,
                                                       LlamaRotaryEmbedding,
                                                       apply_rotary_pos_emb)
 
 import flashmodels.tensor_parallel as tensor_parallel
+
+
+class LlamaModel(LlamaPreTrainedModel):
+    """
+    Transformer decoder consisting of *config.num_hidden_layers* layers. Each layer is a [`LlamaDecoderLayer`]
+
+    Args:
+        config: LlamaConfig
+    """
+    def __init__(self, config: LlamaConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size,
+                                         self.padding_idx)
+        self.layers = nn.ModuleList([
+            LlamaDecoderLayer(config, layer_idx)
+            for layer_idx in range(config.num_hidden_layers)
+        ])
+        self.norm = LlamaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.gradient_checkpointing = False
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Union[Cache,
+                                        List[torch.FloatTensor]]] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+    ) -> Union[Tuple, BaseModelOutputWithPast]:
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = (output_hidden_states
+                                if output_hidden_states is not None else
+                                self.config.output_hidden_states)
+        use_cache = use_cache if use_cache is not None else self.config.use_cache
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError(
+                "You cannot specify both input_ids and inputs_embeds at the same time, and must specify either one"
+            )
+
+        if self.gradient_checkpointing and self.training and use_cache:
+            logger.warning_once(
+                "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`."
+            )
+            use_cache = False
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        return_legacy_cache = False
+        if use_cache and not isinstance(
+                past_key_values,
+                Cache):  # kept for BC (non `Cache` `past_key_values` inputs)
+            return_legacy_cache = True
+            past_key_values = DynamicCache.from_legacy_cache(past_key_values)
+
+        if cache_position is None:
+            past_seen_tokens = past_key_values.get_seq_length(
+            ) if past_key_values is not None else 0
+            cache_position = torch.arange(past_seen_tokens,
+                                          past_seen_tokens +
+                                          inputs_embeds.shape[1],
+                                          device=inputs_embeds.device)
+        if position_ids is None:
+            position_ids = cache_position.unsqueeze(0)
+
+        if os.getenv('CP_SIZE', None):
+            position_ids = context_parallel.split_forward_gather_backward(
+                position_ids, 1, context_parallel.get_intra_cp_process_group())
+            inputs_embeds = context_parallel.split_forward_gather_backward(
+                inputs_embeds, 1,
+                context_parallel.get_intra_cp_process_group())
+
+        causal_mask = self._update_causal_mask(attention_mask, inputs_embeds,
+                                               cache_position, past_key_values,
+                                               output_attentions)
+
+        # embed positions
+        hidden_states = inputs_embeds
+        # decoder layers
+        all_hidden_states = () if output_hidden_states else None
+        all_self_attns = () if output_attentions else None
+        next_decoder_cache = None
+
+        for decoder_layer in self.layers:
+            if output_hidden_states:
+                all_hidden_states += (hidden_states, )
+
+            if self.gradient_checkpointing and self.training:
+                layer_outputs = self._gradient_checkpointing_func(
+                    decoder_layer.__call__,
+                    hidden_states,
+                    causal_mask,
+                    position_ids,
+                    past_key_values,
+                    output_attentions,
+                    use_cache,
+                    cache_position,
+                )
+            else:
+                layer_outputs = decoder_layer(
+                    hidden_states,
+                    attention_mask=causal_mask,
+                    position_ids=position_ids,
+                    past_key_value=past_key_values,
+                    output_attentions=output_attentions,
+                    use_cache=use_cache,
+                    cache_position=cache_position,
+                )
+
+            hidden_states = layer_outputs[0]
+
+            if use_cache:
+                next_decoder_cache = layer_outputs[
+                    2 if output_attentions else 1]
+
+            if output_attentions:
+                all_self_attns += (layer_outputs[1], )
+
+        if os.getenv('CP_SIZE', None):
+            hidden_states = context_parallel.gather_forward_split_backward(
+                hidden_states, 1,
+                context_parallel.get_intra_cp_process_group())
+
+        hidden_states = self.norm(hidden_states)
+
+        # add hidden states from the last decoder layer
+        if output_hidden_states:
+            all_hidden_states += (hidden_states, )
+
+        # add hidden states from the last decoder layer
+        if output_hidden_states:
+            all_hidden_states += (hidden_states, )
+
+        next_cache = next_decoder_cache if use_cache else None
+        if return_legacy_cache:
+            next_cache = next_cache.to_legacy_cache()
+
+        if not return_dict:
+            return tuple(
+                v for v in
+                [hidden_states, next_cache, all_hidden_states, all_self_attns]
+                if v is not None)
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=next_cache,
+            hidden_states=all_hidden_states,
+            attentions=all_self_attns,
+        )
+
+    def _update_causal_mask(
+        self,
+        attention_mask: torch.Tensor,
+        input_tensor: torch.Tensor,
+        cache_position: torch.Tensor,
+        past_key_values: Cache,
+        output_attentions: bool,
+    ):
+        # TODO: As of torch==2.2.0, the `attention_mask` passed to the model in `generate` is 2D and of dynamic length even when the static
+        # KV cache is used. This is an issue for torch.compile which then recaptures cudagraphs at each decode steps due to the dynamic shapes.
+        # (`recording cudagraph tree for symint key 13`, etc.), which is VERY slow. A workaround is `@torch.compiler.disable`, but this prevents using
+        # `fullgraph=True`. See more context in https://github.com/huggingface/transformers/pull/29114
+
+        if self.config._attn_implementation == "flash_attention_2":
+            if attention_mask is not None and 0.0 in attention_mask:
+                return attention_mask
+            return None
+
+        # For SDPA, when possible, we will rely on its `is_causal` argument instead of its `attn_mask` argument, in
+        # order to dispatch on Flash Attention 2. This feature is not compatible with static cache, as SDPA will fail
+        # to infer the attention mask.
+        past_seen_tokens = past_key_values.get_seq_length(
+        ) if past_key_values is not None else 0
+        using_static_cache = isinstance(past_key_values, StaticCache)
+
+        # When output attentions is True, sdpa implementation's forward method calls the eager implementation's forward
+        if self.config._attn_implementation == "sdpa" and not using_static_cache and not output_attentions:
+            if AttentionMaskConverter._ignore_causal_mask_sdpa(
+                    attention_mask,
+                    inputs_embeds=input_tensor,
+                    past_key_values_length=past_seen_tokens,
+                    is_training=self.training,
+            ):
+                return None
+
+        dtype, device = input_tensor.dtype, input_tensor.device
+        min_dtype = torch.finfo(dtype).min
+        sequence_length = input_tensor.shape[1]
+        if using_static_cache:
+            target_length = past_key_values.get_max_length()
+        else:
+            target_length = (attention_mask.shape[-1] if isinstance(
+                attention_mask, torch.Tensor) else past_seen_tokens +
+                             sequence_length + 1)
+
+        if attention_mask is not None and attention_mask.dim() == 4:
+            # in this case we assume that the mask comes already in inverted form and requires no inversion or slicing
+            if attention_mask.max() != 0:
+                raise ValueError(
+                    "Custom 4D attention mask should be passed in inverted form with max==0`"
+                )
+            causal_mask = attention_mask
+        else:
+            causal_mask = torch.full((sequence_length, target_length),
+                                     fill_value=min_dtype,
+                                     dtype=dtype,
+                                     device=device)
+            if sequence_length != 1:
+                causal_mask = torch.triu(causal_mask, diagonal=1)
+            causal_mask *= torch.arange(
+                target_length, device=device) > cache_position.reshape(-1, 1)
+            causal_mask = causal_mask[None, None, :, :].expand(
+                input_tensor.shape[0], 1, -1, -1)
+            if attention_mask is not None:
+                causal_mask = causal_mask.clone(
+                )  # copy to contiguous memory for in-place edit
+                mask_length = attention_mask.shape[-1]
+                padding_mask = causal_mask[:, :, :, :
+                                           mask_length] + attention_mask[:,
+                                                                         None,
+                                                                         None, :]
+                padding_mask = padding_mask == 0
+                causal_mask[:, :, :, :
+                            mask_length] = causal_mask[:, :, :, :
+                                                       mask_length].masked_fill(
+                                                           padding_mask,
+                                                           min_dtype)
+        if (self.config._attn_implementation == "sdpa"
+                and attention_mask is not None
+                and attention_mask.device.type == "cuda"
+                and not output_attentions):
+            # Attend to all tokens in fully masked rows in the causal_mask, for example the relevant first rows when
+            # using left padding. This is required by F.scaled_dot_product_attention memory-efficient attention path.
+            # Details: https://github.com/pytorch/pytorch/issues/110213
+            causal_mask = AttentionMaskConverter._unmask_unattended(
+                causal_mask, min_dtype)
+
+        return causal_mask
 
 
 class Linear3d(nn.Module):
@@ -512,7 +773,8 @@ def flash_attn_fwd(
         return self.o_proj(einops.rearrange(
             output, "b s h d -> b s (h d)")), None, past_key_value
 
-    from torchacc.ops import flash_attn_varlen_xla, spmd_flash_attn_varlen_xla
+    from torchacc.ops import (flash_attn_varlen_xla, flash_attn_xla,
+                              spmd_flash_attn_varlen_xla)
     bsz, q_len, _ = hidden_states.size()
 
     query_states = (self.q_proj(hidden_states).view(bsz, q_len, self.num_heads,
@@ -574,13 +836,12 @@ def flash_attn_fwd(
                                             partition_spec=partition_spec)
     else:
 
-        output = flash_attn_varlen_xla(q,
-                                       k,
-                                       v,
-                                       attention_mask,
-                                       dropout_p=0.0,
-                                       softmax_scale=None,
-                                       causal=True)
+        output = flash_attn_xla(query_states,
+                                key_states,
+                                value_states,
+                                dropout_p=0.0,
+                                softmax_scale=None,
+                                causal=True)
 
     output = einops.rearrange(output, "b s h d -> b s (h d)")
 

--- a/flashmodels/patch/llama_model.py
+++ b/flashmodels/patch/llama_model.py
@@ -516,8 +516,6 @@ def flash_attn_fwd(
             q,
             k,
             v,
-            # torch.tensor([q_len * ulysses_sp_num]),
-            # torch.tensor([q_len * ulysses_sp_num]),
             None,
             None,  # Use fixed len FA
             dropout_p=0.0,

--- a/flashmodels/patch/llama_model.py
+++ b/flashmodels/patch/llama_model.py
@@ -18,7 +18,6 @@ from transformers.models.llama.modeling_llama import (ACT2FN, LlamaRMSNorm,
 
 import flashmodels.tensor_parallel as tensor_parallel
 
-
 class Linear3d(nn.Module):
     """ Custom Linear layer"""
     def __init__(self, in_dim, out_dim, keep_dim):
@@ -221,9 +220,12 @@ class LlamaAttention(nn.Module):
         value_states = self.v_proj(hidden_states)
 
         if self.tp_col_mesh is not None:
-            query_states.register_hook(lambda grad: _grad_shard_tp(grad))
-            key_states.register_hook(lambda grad: _grad_shard_tp(grad))
-            value_states.register_hook(lambda grad: _grad_shard_tp(grad))
+            if query_states.requires_grad:
+                query_states.register_hook(lambda grad: _grad_shard_tp(grad))
+            if key_states.requires_grad:
+                key_states.register_hook(lambda grad: _grad_shard_tp(grad))
+            if value_states.requires_grad:
+                value_states.register_hook(lambda grad: _grad_shard_tp(grad))
         elif tensor_parallel.get_tp_context().is_initialized():
             tensor_parallel.fx_register_hook(query_states, ("dp", None, "tp"))
             tensor_parallel.fx_register_hook(key_states, ("dp", None, "tp"))
@@ -250,7 +252,7 @@ class LlamaAttention(nn.Module):
         query_states = query_states.transpose(1, 2)
         key_states = key_states.transpose(1, 2)
         value_states = value_states.transpose(1, 2)
-
+        print(f"{query_states.size()=} {key_states.size()=} {value_states.size()=}")
         if self.sp_mesh_4d is not None:
             # insert all-to-all
             mark_sharding(query_states, self.sp_mesh_4d, (0, 1, 2, 3))
@@ -263,9 +265,15 @@ class LlamaAttention(nn.Module):
         kv_seq_len = key_states.shape[-2]
         if past_key_value is not None:
             kv_seq_len += past_key_value[0].shape[-2]
-        cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
-        query_states, key_states = apply_rotary_pos_emb(
-            query_states, key_states, cos, sin, position_ids)
+            
+        if version.parse(transformers.__version__) >= version.parse('4.36'):
+            cos, sin = self.rotary_emb(value_states, position_ids=position_ids)
+            query_states, key_states = apply_rotary_pos_emb(
+                query_states, key_states, cos, sin)
+        else:
+            cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+            query_states, key_states = apply_rotary_pos_emb(
+                query_states, key_states, cos, sin, position_ids)
         # [bsz, nh, t, hd]
 
         if past_key_value is not None:
@@ -275,7 +283,40 @@ class LlamaAttention(nn.Module):
 
         past_key_value = (key_states, value_states) if use_cache else None
 
-        attn_output, attn_weights = self.core_attn(query_states, key_states,
+        from torchacc.ops import spmd_flash_attn_varlen_xla
+        attn_output = None
+        attn_weights = None
+        if os.getenv("ACC_FLASH_ATTN", "0") == "1":
+            query_states = einops.rearrange(query_states,
+                                        "b h s ... -> (b s) h ...")
+            key_states = einops.rearrange(key_states, "b h s ... -> (b s) h ...")
+            value_states = einops.rearrange(value_states,
+                                            "b h s ... -> (b s) h ...")
+            max_s = q_len
+            cu_q_lens = torch.arange(0, (bsz / self.dp_num + 1) * q_len,
+                                step=q_len,
+                                dtype=torch.int32,
+                                device=query_states.device)
+            device_ids = np.array(range(self.dp_num * self.tp_num))
+            mesh = xs.Mesh(device_ids, (self.dp_num, self.tp_num), ('fsdp', 'tensor'))
+            partition_spec = ('fsdp', None, None)
+            attn_output = spmd_flash_attn_varlen_xla(
+                query_states,
+                key_states,
+                value_states,
+                cu_q_lens,
+                cu_q_lens,
+                max_s,
+                max_s,
+                dropout_p=0.0,
+                softmax_scale=None,
+                causal=True,
+                mesh = mesh,
+                partition_spec = partition_spec                
+            )
+            attn_output = einops.rearrange(attn_output, "(b s) ... -> b s ...", b=bsz)
+        else:
+            attn_output, attn_weights = self.core_attn(query_states, key_states,
                                                    value_states,
                                                    attention_mask)
         if self.sp_mesh_4d is not None:
@@ -286,11 +327,13 @@ class LlamaAttention(nn.Module):
         attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)
         if self.tp_col_mesh is not None:
             mark_sharding(attn_output, self.tp_col_mesh, (0, 1, 2))
-            attn_output.register_hook(lambda grad: _grad_shard_tp(grad))
+            if attn_output.requires_grad:
+                attn_output.register_hook(lambda grad: _grad_shard_tp(grad))
         elif self.sp_mesh_3d is not None:
             # insert all-to-all
             mark_sharding(attn_output, self.sp_mesh_3d, (0, 1, 2))
-            attn_output.register_hook(lambda grad: _grad_shard_sp_3d(grad))
+            if attn_output.requires_grad:
+                attn_output.register_hook(lambda grad: _grad_shard_sp_3d(grad))
         elif tensor_parallel.get_tp_context().is_initialized():
             attn_output = tensor_parallel.fx_mark_sharding(attn_output,
                                                            ("dp", None, "tp"),
@@ -315,7 +358,7 @@ class LlamaAttention(nn.Module):
 
 
 class LlamaDecoderLayer(nn.Module):
-    def __init__(self, config: LlamaConfig):
+    def __init__(self, config: LlamaConfig, layer_idx: int):
         super().__init__()
         self.hidden_size = config.hidden_size
         self.self_attn = LlamaAttention(config=config)
@@ -337,6 +380,7 @@ class LlamaDecoderLayer(nn.Module):
         past_key_value: Optional[Tuple[torch.Tensor]] = None,
         output_attentions: Optional[bool] = False,
         use_cache: Optional[bool] = False,
+        cache_position: Optional[torch.LongTensor] = None,
     ) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor,
                                                  torch.FloatTensor]]]:
         """
@@ -401,6 +445,8 @@ def flash_attn_fwd(
     self,
     hidden_states: torch.Tensor,
     fsdp_num: int = None,
+    ulysses_sp_num: int = None,
+    tp_num: int = None,
     use_spmd: bool = None,
     attention_mask: Optional[torch.Tensor] = None,
     position_ids: Optional[torch.Tensor] = None,
@@ -410,6 +456,33 @@ def flash_attn_fwd(
     cache_position: Optional[torch.LongTensor] = None,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor],
            Optional[Tuple[torch.Tensor]]]:
+
+    if tp_num > 1:
+        # dp + tp + sp + zero3
+        pass
+
+    if ulysses_sp_num > 1 and not use_spmd:
+        bsz, q_len, _ = hidden_states.size()
+        q = self.q_proj(hidden_states).view(bsz, q_len, self.num_heads,
+                                           self.head_dim)
+        k = self.k_proj(hidden_states).view(bsz, q_len, self.num_key_value_heads,
+                                           self.head_dim)
+        v = self.v_proj(hidden_states).view(bsz, q_len, self.num_key_value_heads,
+                                           self.head_dim)
+        cp_func = context_parallel.ulysses
+        cp_group = context_parallel.get_context_parallel_group()
+        output = cp_func(q, 
+                            k,
+                            v,
+                            torch.tensor([q_len]),
+                            torch.tensor([q_len]),
+                            dropout_p = 0.0,
+                            softmax_scale=None,
+                            causal=True,
+                            process_group=cp_group)
+        return self.o_proj(einops.rearrange(
+            output, "b s h d -> b s (h d)")), None, past_key_value
+
     from torchacc.ops import flash_attn_varlen_xla, spmd_flash_attn_varlen_xla
     bsz, q_len, _ = hidden_states.size()
 

--- a/flashmodels/patch/llama_model.py
+++ b/flashmodels/patch/llama_model.py
@@ -526,7 +526,7 @@ def flash_attn_fwd(
 
     output = None
     if use_spmd:
-        cu_q_lens = torch.arange(0, (bsz / fsdp_num + 1) * q_len,
+        cu_q_lens = torch.arange(0, (bsz / (fsdp_num // ulysses_sp_num) + 1) * q_len,
                                  step=q_len,
                                  dtype=torch.int32,
                                  device=q.device)

--- a/flashmodels/patch/patch.py
+++ b/flashmodels/patch/patch.py
@@ -42,7 +42,7 @@ def patch_llama(fsdp_num,
                 spmd_fsdp=False):
     transformers.models.llama.modeling_llama._make_causal_mask = make_causal_mask
 
-    if ulysses_sp_num > 1 and not spmd_fsdp:
+    if ulysses_sp_num > 1 and not spmd_fsdp and os.environ.get("XLA_USE_SPMD") == "0":
         transformers.models.llama.LlamaModel.forward = LlamaModel.forward
         os.environ["CP_SIZE"] = str(ulysses_sp_num)
 

--- a/flashmodels/patch/patch.py
+++ b/flashmodels/patch/patch.py
@@ -10,7 +10,8 @@ from packaging import version
 
 from flashmodels.logger import logger
 from flashmodels.patch.llama_model import (LlamaAttention, LlamaDecoderLayer,
-                                           LlamaMLP, flash_attn_fwd,
+                                           LlamaMLP, LlamaModel,
+                                           flash_attn_fwd,
                                            flash_attn_prep_mask,
                                            make_causal_mask)
 
@@ -43,7 +44,7 @@ def patch_llama(fsdp_num,
     transformers.models.llama.modeling_llama._make_causal_mask = make_causal_mask
 
     if ulysses_sp_num > 1 and not spmd_fsdp and os.environ.get(
-            "XLA_USE_SPMD") == "0":
+            "XLA_USE_SPMD", "0") == "0":
         transformers.models.llama.LlamaModel.forward = LlamaModel.forward
         os.environ["CP_SIZE"] = str(ulysses_sp_num)
 

--- a/flashmodels/patch/patch.py
+++ b/flashmodels/patch/patch.py
@@ -35,7 +35,11 @@ def rewrite_load():
     exec(modified, transformers.modeling_utils.__dict__)
 
 
-def patch_llama(fsdp_num, ulysses_sp_num, tp_num, use_tp=False, spmd_fsdp=False):
+def patch_llama(fsdp_num,
+                ulysses_sp_num,
+                tp_num,
+                use_tp=False,
+                spmd_fsdp=False):
     transformers.models.llama.modeling_llama._make_causal_mask = make_causal_mask
 
     if ulysses_sp_num > 1 and not spmd_fsdp:

--- a/flashmodels/patch/patch.py
+++ b/flashmodels/patch/patch.py
@@ -20,8 +20,11 @@ def rewrite_load():
     """Rewrite `torch.load` in `from_pretrain` in case to use mmap to reduce the CPU
     memory pressure of loading multiple copies of data under multiple processes"""
     source = inspect.getsource(transformers.modeling_utils)
-    modified = re.sub(r"torch\.load\((?![^)]*mmap[^)]*\))([^)]*)\)",
-                      r"torch.load(\g<1>, mmap=True)", source)
+    modified = re.sub(
+        r"torch\.load\((?![^)]*mmap[^)]*\))([^)]*)\)",
+        r"torch.load(\g<1>, mmap=True)"
+        if version.parse(transformers.__version__) <= version.parse('4.36')
+        else r"torch.load(\g<1> mmap=True)", source)
     modified = re.sub(r"partial\(torch.load,(?![^)]*mmap[^)]*\))([^)]*)\)",
                       r"partial(torch.load,\g<1>, mmap=True)", modified)
     if (int(os.environ.get("LOCAL_RANK", 0)) == 0):

--- a/flashmodels/patch/patch.py
+++ b/flashmodels/patch/patch.py
@@ -35,10 +35,10 @@ def rewrite_load():
     exec(modified, transformers.modeling_utils.__dict__)
 
 
-def patch_llama(fsdp_num, ulysses_sp_num, use_tp=False):
+def patch_llama(fsdp_num, ulysses_sp_num, tp_num, use_tp=False, spmd_fsdp=False):
     transformers.models.llama.modeling_llama._make_causal_mask = make_causal_mask
 
-    if ulysses_sp_num > 1:
+    if ulysses_sp_num > 1 and not spmd_fsdp:
         transformers.models.llama.LlamaModel.forward = LlamaModel.forward
         os.environ["CP_SIZE"] = str(ulysses_sp_num)
 
@@ -61,9 +61,10 @@ def patch_llama(fsdp_num, ulysses_sp_num, use_tp=False):
         def wrapper(*args, **kwargs):
             kwargs["attention_mask"] = None
             # print("call wrapper")
-            if os.getenv("ACC_FLASH_ATTN", "0") == "1":
+            if os.getenv("ACC_FLASH_ATTN", "0") == "1" and not use_tp:
                 kwargs["fsdp_num"] = fsdp_num
                 kwargs["ulysses_sp_num"] = ulysses_sp_num
+                kwargs["tp_num"] = tp_num
                 kwargs["use_spmd"] = os.environ.get("XLA_USE_SPMD", "0") == "1"
             return func(*args, **kwargs)
 

--- a/flashmodels/patch/patch.py
+++ b/flashmodels/patch/patch.py
@@ -42,7 +42,8 @@ def patch_llama(fsdp_num,
                 spmd_fsdp=False):
     transformers.models.llama.modeling_llama._make_causal_mask = make_causal_mask
 
-    if ulysses_sp_num > 1 and not spmd_fsdp and os.environ.get("XLA_USE_SPMD") == "0":
+    if ulysses_sp_num > 1 and not spmd_fsdp and os.environ.get(
+            "XLA_USE_SPMD") == "0":
         transformers.models.llama.LlamaModel.forward = LlamaModel.forward
         os.environ["CP_SIZE"] = str(ulysses_sp_num)
 

--- a/flashmodels/patch/patch.py
+++ b/flashmodels/patch/patch.py
@@ -64,7 +64,6 @@ def patch_llama(fsdp_num,
     def wrap_for_flash_attention(func):
         def wrapper(*args, **kwargs):
             kwargs["attention_mask"] = None
-            # print("call wrapper")
             if os.getenv("ACC_FLASH_ATTN", "0") == "1" and not use_tp:
                 kwargs["fsdp_num"] = fsdp_num
                 kwargs["ulysses_sp_num"] = ulysses_sp_num

--- a/flashmodels/trainer.py
+++ b/flashmodels/trainer.py
@@ -250,8 +250,11 @@ class Trainer(object):
                 and not self.args.pp_num > 1) or (self.args.fsdp_num > 1
                                                   and self.args.spmd_fsdp):
             devices_ids = np.arange(self.args.world_size)
-            dp_num = self.args.dp_num if self.args.dp_num > 1 else int(self.args.fsdp_num / self.args.sp_num)
-            mesh = Mesh(devices_ids, (dp_num, self.args.tp_num, self.args.sp_num), ("x", "y", "z"))
+            dp_num = self.args.dp_num if self.args.dp_num > 1 else int(
+                self.args.fsdp_num / self.args.sp_num)
+            mesh = Mesh(devices_ids,
+                        (dp_num, self.args.tp_num, self.args.sp_num),
+                        ("x", "y", "z"))
             loader = pl.MpDeviceLoader(self.loader,
                                        self.device,
                                        input_sharding=xs.ShardingSpec(

--- a/flashmodels/trainer.py
+++ b/flashmodels/trainer.py
@@ -250,12 +250,12 @@ class Trainer(object):
                 and not self.args.pp_num > 1) or (self.args.fsdp_num > 1
                                                   and self.args.spmd_fsdp):
             devices_ids = np.arange(self.args.world_size)
-            dp_num = self.args.dp_num if self.args.dp_num > 1 else self.args.fsdp_num
-            mesh = Mesh(devices_ids, (dp_num, self.args.tp_num), ("x", "y"))
+            dp_num = self.args.dp_num if self.args.dp_num > 1 else int(self.args.fsdp_num / self.args.sp_num)
+            mesh = Mesh(devices_ids, (dp_num, self.args.tp_num, self.args.sp_num), ("x", "y", "z"))
             loader = pl.MpDeviceLoader(self.loader,
                                        self.device,
                                        input_sharding=xs.ShardingSpec(
-                                           mesh, (0, None)))
+                                           mesh, ("x", None)))
 
         for epoch in range(0, self.args.num_train_epochs):
             self.model.train()

--- a/flashmodels/trainer.py
+++ b/flashmodels/trainer.py
@@ -88,7 +88,7 @@ class Trainer(object):
             samples_per_step = float(
               self.args.micro_batch_size * self.args.gradient_accumulation_steps \
                   / time_each_step)
-            samples_per_step = samples_per_step * self.args.fsdp_num * self.args.dp_num
+            samples_per_step = samples_per_step * self.args.fsdp_num * self.args.dp_num / self.args.sp_num
             begin_time = time.time()
             train_format_string = "[TRAIN] {{epoch: {}, iteration: {}, batch_size: {}," \
                 " loss: {:.8f}, throughput: {:.2f} samples/sec}}"


### PR DESCRIPTION
This PR introduces support for two type of combination of parallelism and a feature for initialization:

- [X]  FSDPv2 + Ulysses
- [X] FSDPv2 + TP + SP
- [X] Low cpu memory usage for ulysses parallelism initialization
- [X] Llama3 model support for TP + SP
- [X] Align the training accuracy of ulysses parallel training and single GPU training
- [x] Align the training accuracy of tensor parallel training and single GPU training

To run the combinations of parallelism, use the following commands:

```bash
# fsdpv2 + ulysses
CUDA_VISIBLE_DEVICES=0,1,2,3 PJRT_ALLOCATOR_FRACTION=0.92 XLA_FLAGS="--xla_disable_hlo_passes=gpu-convert-async-collectives-to-sync,triton-autotuner" \
XLA_USE_SPMD=1  ./examples/run.sh --model ./hf_models/config/llama-3-1b --mbs 1 --fsdp 4 --sp_num 2 --spmd_fsdp --max_seq_length 8192

# fsdpv2 + tp + sp
CUDA_VISIBLE_DEVICES=0,1,2,3 PJRT_ALLOCATOR_FRACTION=0.92 XLA_FLAGS=" --xla_disable_hlo_passes=gpu-convert-async-collectives-to-sync,triton-autotuner" \
XLA_USE_SPMD=1 ./examples/run.sh --model ./hf_models/config/llama-3-1b --mbs 1 --fsdp 2 --tp 2 --sp --spmd_fsdp --max_seq_length 8192
```


